### PR TITLE
Improvements to maintenance script and fix job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 ## ChangeLog for RottenLinks
 
 ### 2.0.1 (17-12-2023)
-* Add `requireExtension` to updateExternalLinks
-* Prevent duplicate entries from being added to rottenlinks table in updateExternalLinks
-* Fix table name used in RottenLinksJob
+* Add `requireExtension` to updateExternalLinks.
+* Remove unnecessary object cache from being added in updateExternalLinks.
+* Prevent duplicate entries from being added to rottenlinks table in updateExternalLinks.
+* Fix table name used in RottenLinksJob.
 
 ### 2.0.0 (15-12-2023)
 * Redesign RottenLinks to not depend on a maintenance script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## ChangeLog for RottenLinks
 
+### 2.0.1 (17-12-2023)
+* Add `requireExtension` to updateExternalLinks
+* Prevent duplicate entries from being added to rottenlinks table in updateExternalLinks
+* Fix table name used in RottenLinksJob
+
 ### 2.0.0 (15-12-2023)
 * Redesign RottenLinks to not depend on a maintenance script
 * Changes how we count page usage on RottenLinks special page. We directly gather this from externallinks table rather then storing it separately.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## ChangeLog for RottenLinks
 
-### 2.0.1 (17-12-2023)
+### 2.0.1 (16-12-2023)
 * Add `requireExtension` to updateExternalLinks.
 * Remove unnecessary object cache from being added in updateExternalLinks.
 * Prevent duplicate entries from being added to rottenlinks table in updateExternalLinks.

--- a/extension.json
+++ b/extension.json
@@ -1,6 +1,6 @@
 {
 	"name": "RottenLinks",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"author": [
 		"John Lewis",
 		"Paladox",

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -68,7 +68,7 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 					->fetchRowCount();
 
 				if ( $rottenLinksCount > 0 ) {
-					// Don't create duplicate entires
+					// Don't create duplicate entries
 					continue;
 				}
 

--- a/includes/RottenLinksJob.php
+++ b/includes/RottenLinksJob.php
@@ -62,7 +62,7 @@ class RottenLinksJob extends Job implements GenericParameterJob {
 
 				$rottenLinksCount = $dbw->newSelectQueryBuilder()
 					->select( 'rl_externallink' )
-					->from( 'externallinks' )
+					->from( 'rottenlinks' )
 					->where( [ 'rl_externallink' => $url ] )
 					->caller( __METHOD__ )
 					->fetchRowCount();

--- a/maintenance/updateExternalLinks.php
+++ b/maintenance/updateExternalLinks.php
@@ -75,7 +75,7 @@ class UpdateExternalLinks extends Maintenance {
 
 			$rottenLinksCount = $dbw->newSelectQueryBuilder()
 				->select( 'rl_externallink' )
-				->from( 'externallinks' )
+				->from( 'rottenlinks' )
 				->where( [ 'rl_externallink' => $url ] )
 				->caller( __METHOD__ )
 				->fetchRowCount();


### PR DESCRIPTION
* Add `requireExtension` to updateExternalLinks.
* Remove unnecessary object cache from being added in updateExternalLinks.
* Prevent duplicate entries from being added to rottenlinks table in updateExternalLinks.
* Fix table name used in RottenLinksJob.